### PR TITLE
Removed unneeded classpath library entries.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,8 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
-	<classpathentry kind="lib" path="libs/group-service.jar" sourcepath="/liferay-jsonws-client-builder"/>
-	<classpathentry kind="lib" path="libs/liferay-sdk-android.jar" sourcepath="/liferay-jsonws-client-builder"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="output" path="bin/classes"/>


### PR DESCRIPTION
Hey Bruno,

In the sample .classpath there are unneeded classpath entries.  Since both the group-service and liferay-sdk-android jars are added under the /libs folder, the <classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/> entry will add those to the project automatically.
